### PR TITLE
[main] Update nextcloud/ocp dependency

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -54,12 +54,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nextcloud-deps/ocp.git",
-                "reference": "1e34a80be034fe9a58057d2e756913363675bddb"
+                "reference": "0b726d37da4d9e0e18de80d34b5bebda959e04e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/1e34a80be034fe9a58057d2e756913363675bddb",
-                "reference": "1e34a80be034fe9a58057d2e756913363675bddb",
+                "url": "https://api.github.com/repos/nextcloud-deps/ocp/zipball/0b726d37da4d9e0e18de80d34b5bebda959e04e4",
+                "reference": "0b726d37da4d9e0e18de80d34b5bebda959e04e4",
                 "shasum": ""
             },
             "require": {
@@ -87,9 +87,9 @@
             "description": "Composer package containing Nextcloud's public API (classes, interfaces)",
             "support": {
                 "issues": "https://github.com/nextcloud-deps/ocp/issues",
-                "source": "https://github.com/nextcloud-deps/ocp/tree/stable25"
+                "source": "https://github.com/nextcloud-deps/ocp/tree/v25.0.7"
             },
-            "time": "2023-05-13T00:33:04+00:00"
+            "time": "2023-06-17T00:38:15+00:00"
         },
         {
             "name": "php-cs-fixer/shim",


### PR DESCRIPTION
Auto-generated update of [nextcloud/ocp](https://github.com/nextcloud-deps/ocp/) dependency