### PR TITLE
Use SPDX license identifier

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -11,7 +11,7 @@
 	<description><![CDATA[Receive a notification when an event in a shared calendar was added, modified or deleted.]]></description>
 
 	<version>2.9.0</version>
-	<licence>agpl</licence>
+	<licence>AGPL-3.0-or-later</licence>
 	<author>Joas Schilling</author>
 
 	<namespace>EventUpdateNotification</namespace>

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	},
 	"name": "nextcloud/event_update_notification",
 	"description": "event update notification",
-	"license": "AGPL",
+	"license": "AGPL-3.0-or-later",
 	"config": {
 		"classmap-authoritative": true,
 		"optimize-autoloader": true,


### PR DESCRIPTION
Using SPDX license identifier supported in info.xml since 31, so no issue given min-version is set to 33 at the moment.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
