### PR TITLE
[main] ci(actions): Update workflow templates from organization template repository

### DIFF
--- a/.github/actions-lock.txt
+++ b/.github/actions-lock.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 d4697182231bf364a34d8dd8b9e52a00 appstore-build-publish.yml
 e6351c608939c31ae1e32923aa82aa10 dependabot-approve-merge.yml
-c5893d7af1998af66d22f8c171ff4448 lint-info-xml.yml
+023b664746d1f2e09a9aaaac772ff7f5 lint-info-xml.yml
 870b483dbcbca59479211270d61546dd lint-php-cs.yml
 ee2b04d185b82fe7dd6fe6d83c6c7b45 lint-php.yml
 482b8c0da56ce273cf3ee464a5ed3290 psalm-matrix.yml

--- a/.github/workflows/lint-info-xml.yml
+++ b/.github/workflows/lint-info-xml.yml
@@ -27,6 +27,8 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
+          sparse-checkout: |
+            appinfo/
 
       - name: Download schema
         run: wget https://raw.githubusercontent.com/nextcloud/appstore/master/nextcloudappstore/api/v1/release/info.xsd


### PR DESCRIPTION
Automated update of all workflow templates from [nextcloud/.github](https://github.com/nextcloud/.github)
- 🆙 Updated [lint-info-xml.yml](https://github.com/nextcloud/.github/commits/master/workflow-templates/lint-info-xml.yml)